### PR TITLE
`enum` changed by `as const`

### DIFF
--- a/src/app/components/componentito/componentito.component.ts
+++ b/src/app/components/componentito/componentito.component.ts
@@ -15,7 +15,6 @@ export class ComponentitoComponent {
   sharedStateAppService = inject(SharedStateAppService)
 
   constructor() {
-    this.user = this.sharedStateAppService.appSignalsState.getSignal(AppSignalKeys.USER);
+    this.user = this.sharedStateAppService.appSignalsState.getSignal<User>(AppSignalKeys.USER);
   }
 }
-

--- a/src/app/services/shared-state-app.service.ts
+++ b/src/app/services/shared-state-app.service.ts
@@ -2,13 +2,12 @@ import { Injectable } from '@angular/core';
 import { SignalsManager } from '../utilities/signals-manager.utility';
 import { User } from '../models';
 
-export enum AppSignalKeys {
-  'USER' = 'user',
-  'TEST' = 'test',
-}
+export const AppSignalKeys = {
+  'USER': 'user',
+  'TEST': 'test',
+} as const
 
 export interface AppSignalState {
-  [key: string]: any;
   [AppSignalKeys.USER]: User;
   [AppSignalKeys.TEST]: string;
 }

--- a/src/app/utilities/signals-manager.utility.ts
+++ b/src/app/utilities/signals-manager.utility.ts
@@ -21,7 +21,7 @@ export class SignalsManager<T extends { [K in keyof T]: any }> {
     this.signalsCollection.set(key, signalObject);
   }
 
-  getSignal(key: keyof T): WritableSignal<T[keyof T]> {
+  getSignal<U>(key: keyof T): WritableSignal<U> {
     const foundSignal = this.signalsCollection.get(key);
     if (!foundSignal) {
       const stringKey = String(key);


### PR DESCRIPTION
### **Explain**

Using `enum` we have some problems with the types parts. We can't use the keys and values to build a reusable/useful type that helps us with the autocomplete. 

_before_
![Screenshot 2023-11-04 at 12 42 36 PM](https://github.com/Gentleman-Programming/Gentleman-Signals-State-Manager/assets/83780950/fa85c6a1-fbc7-428c-9554-efe9716b88ea)

I saw in the Open Source community use `as const` to fix this.

_after_
<img width="344" alt="Screenshot 2023-11-04 at 6 22 22 PM" src="https://github.com/Gentleman-Programming/Gentleman-Signals-State-Manager/assets/83780950/108a8b93-32c2-4cab-bebf-08d0bd8bec5a">

Also, it still works like an enum. Please check it out a leave your comments. 

In another part. I had to modify the `getSignal` method to specify which type I wanted to be returned. I'm not a big fan of adding a return type but for now is necessary. 

### **Commits**

fix: AppSignalKeys is not a enum, now POJO type.
fix: getSignal was returned WritebleSignal - any, now you can specify the type.