### PR TITLE
[DX]: Provide an easy way to inject initial state from environment

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -1,0 +1,61 @@
+# 🚀 gentleman-signals-state-manager: ¡Manejando señales de estado como un caballero! 🎩
+
+## Descripción
+`GManagerService` es el corazón de la librería `gentleman-signals-state-manager`, un servicio de manejo de señales de estado en Angular que no solo es elegante, ¡sino que también es super potente!
+
+### ¿Por qué usar `gentleman-signals-state-manager` en lugar de señales 'crudas'?
+
+- 🎯 **Agnóstico a los frameworks**: Diseñado para funcionar con Angular, pero gracias a su diseño agnóstico, podría ser fácilmente adaptado para cualquier librería o framework de frontend.
+
+- 💼 **Manejo de señales simplificado**: Olvídate del manejo manual de las señales y deja que `GManagerService` se ocupe de todo. Añade, actualiza y obtén señales con facilidad.
+
+- 🛡️ **Robusto**: Maneja errores automáticamente, protegiendo tu aplicación contra señales inexistentes o duplicadas.
+
+- 🚀 **Rendimiento optimizado**: Al manejar las señales de manera eficiente, `GManagerService` ayuda a mantener tu aplicación rápida y ágil.
+
+## Uso Recomendado
+Para comenzar a utilizar `gentleman-signals-state-manager` en tu propio proyecto, sigue el formato que se muestra a continuación:
+
+```typescript
+// Importa lo necesario
+import { Inject, Injectable } from "@angular/core";
+import { GENTLEMAN_DEFAULT_STATE, GManagerService } from "gentleman-signals-state-manager";
+
+// Define tu propio servicio
+@Injectable({
+  providedIn: 'root',
+})
+export class SignalsManagerService<T> {
+  signalsManager: GManagerService<T>;
+
+  // Inyecta el estado inicial
+  constructor(@Inject(GENTLEMAN_DEFAULT_STATE) defaultState: T) {
+    this.signalsManager = new GManagerService(defaultState);
+  }
+}
+```
+
+Establece tu estado inicial dentro de tu `app.config.ts`
+
+```ts
+// app.config.ts
+import { ApplicationConfig } from '@angular/core';
+import { provideInitialState } from 'gentleman-signals-state-manager'
+
+const initial initialState = {
+  isLogged: false
+}
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideInitialState(initialState),
+    provideRouter(routes)
+  ]
+};
+```
+
+Para un ejemplo completo de cómo utilizar `gentleman-signals-state-manager`, visita la carpeta "example" en nuestro repositorio de GitHub.
+
+Para instalar `gentleman-signals-state-manager` en tu proyecto, dirígete a [la página del paquete en npm](https://www.npmjs.com/package/gentleman-signals-state-manager).
+
+¡Estás listo para comenzar a manejar señales de estado como un verdadero caballero! 🎩🚀

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-# 🚀 gentleman-signals-state-manager: ¡Manejando señales de estado como un caballero! 🎩
-
-## English 🎩
+# 🚀 gentleman-signals-state-manager: !Managing signal state as a gentleman! 🎩
 
 ## Description
 `GManagerService` is at the heart of the `gentleman-signals-state-manager` library, a state signal management service in Angular that is not only classy, but super powerful!
@@ -37,29 +35,23 @@ export class SignalsManagerService<T> {
 }
 ```
 
-And then, in your main component:
+Provide your initial state inside your `app.config.ts`
 
-```typescript
-// Provide your service and the initial state
-@Component({
-  selector: 'app-root',
-  standalone: true,
-  imports: [
-    CommonModule,
-    RouterOutlet,
-    ComponentitoComponent,
-    Componentito2Component,
-  ],
-  providers: [
-    SignalsManagerService<AppSignalState>,
-    { provide: GENTLEMAN_DEFAULT_STATE, useValue: emptyAppSignalState },
-  ],
-  templateUrl: './app.component.html',
-  styleUrls: ['./app.component.scss'],
-})
-export class AppComponent {
-  title = 'Gentleman Signals State Manager';
+```ts
+// app.config.ts
+import { ApplicationConfig } from '@angular/core';
+import { provideInitialState } from 'gentleman-signals-state-manager'
+
+const initial initialState = {
+  isLogged: false,
 }
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideInitialState(initialState),
+    provideRouter(routes)
+  ]
+};
 ```
 
 For a complete example of how to use `gentleman-signals-state-manager`, check out the "example" folder in our GitHub repository.
@@ -67,72 +59,3 @@ For a complete example of how to use `gentleman-signals-state-manager`, check ou
 To install `gentleman-signals-state-manager` in your project, head over to [the package page on npm](https://www.npmjs.com/package/gentleman-signals-state-manager).
 
 You're all set to start managing state signals like a true gentleman! 🎩🚀
-
-## English 🎩
-
-## Descripción
-`GManagerService` es el corazón de la librería `gentleman-signals-state-manager`, un servicio de manejo de señales de estado en Angular que no solo es elegante, ¡sino que también es super potente!
-
-### ¿Por qué usar `gentleman-signals-state-manager` en lugar de señales 'crudas'?
-
-- 🎯 **Agnóstico a los frameworks**: Diseñado para funcionar con Angular, pero gracias a su diseño agnóstico, podría ser fácilmente adaptado para cualquier librería o framework de frontend.
-
-- 💼 **Manejo de señales simplificado**: Olvídate del manejo manual de las señales y deja que `GManagerService` se ocupe de todo. Añade, actualiza y obtén señales con facilidad.
-
-- 🛡️ **Robusto**: Maneja errores automáticamente, protegiendo tu aplicación contra señales inexistentes o duplicadas.
-
-- 🚀 **Rendimiento optimizado**: Al manejar las señales de manera eficiente, `GManagerService` ayuda a mantener tu aplicación rápida y ágil.
-
-## Uso Recomendado
-Para comenzar a utilizar `gentleman-signals-state-manager` en tu propio proyecto, sigue el formato que se muestra a continuación:
-
-```typescript
-// Importa lo necesario
-import { Inject, Injectable } from "@angular/core";
-import { GENTLEMAN_DEFAULT_STATE, GManagerService } from "gentleman-signals-state-manager";
-
-// Define tu propio servicio
-@Injectable({
-  providedIn: 'root',
-})
-export class SignalsManagerService<T> {
-  signalsManager: GManagerService<T>;
-
-  // Inyecta el estado inicial
-  constructor(@Inject(GENTLEMAN_DEFAULT_STATE) defaultState: T) {
-    this.signalsManager = new GManagerService(defaultState);
-  }
-}
-```
-
-Y luego, en tu componente principal:
-
-```typescript
-// Proporciona tu servicio y el estado inicial
-@Component({
-  selector: 'app-root',
-  standalone: true,
-  imports: [
-    CommonModule,
-    RouterOutlet,
-    ComponentitoComponent,
-    Componentito2Component,
-  ],
-  providers: [
-    SignalsManagerService<AppSignalState>,
-    { provide: GENTLEMAN_DEFAULT_STATE, useValue: emptyAppSignalState },
-  ],
-  templateUrl: './app.component.html',
-  styleUrls: ['./app.component.scss'],
-})
-export class AppComponent {
-  title = 'Gentleman Signals State Manager';
-}
-```
-
-Para un ejemplo completo de cómo utilizar `gentleman-signals-state-manager`, visita la carpeta "example" en nuestro repositorio de GitHub.
-
-Para instalar `gentleman-signals-state-manager` en tu proyecto, dirígete a [la página del paquete en npm](https://www.npmjs.com/package/gentleman-signals-state-manager).
-
-¡Estás listo para comenzar a manejar señales de estado como un verdadero caballero! 🎩🚀
-

--- a/example/src/app/app.component.ts
+++ b/example/src/app/app.component.ts
@@ -4,7 +4,7 @@ import { RouterOutlet } from '@angular/router';
 import { Componentito2Component, ComponentitoComponent } from './components';
 import { GENTLEMAN_DEFAULT_STATE } from 'gentleman-signals-state-manager';
 import { SignalsManagerService } from './services/signals-manager.service';
-import { AppSignalState, emptyAppSignalState } from './models/signals.model';
+import { AppSignalState } from './models/signals.model';
 
 @Component({
   selector: 'app-root',
@@ -14,10 +14,6 @@ import { AppSignalState, emptyAppSignalState } from './models/signals.model';
     RouterOutlet,
     ComponentitoComponent,
     Componentito2Component,
-  ],
-  providers: [
-    SignalsManagerService<AppSignalState>,
-    { provide: GENTLEMAN_DEFAULT_STATE, useValue: emptyAppSignalState },
   ],
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss'],

--- a/example/src/app/app.config.ts
+++ b/example/src/app/app.config.ts
@@ -1,8 +1,12 @@
 import { ApplicationConfig } from '@angular/core';
 import { provideRouter } from '@angular/router';
-
+import { provideInitialState } from 'gentleman-signals-state-manager'
 import { routes } from './app.routes';
+import { emptyAppSignalState } from './models/signals.model'
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideRouter(routes) ]
+  providers: [
+    provideInitialState(emptyAppSignalState),
+    provideRouter(routes)
+  ]
 };

--- a/example/src/app/components/componentito/componentito.component.ts
+++ b/example/src/app/components/componentito/componentito.component.ts
@@ -1,17 +1,13 @@
 import { CommonModule } from '@angular/common';
 import { Component, WritableSignal, inject } from '@angular/core';
 import { User } from '../../models';
-import { AppSignalKeys, emptyAppSignalState } from 'src/app/models/signals.model';
-import { GENTLEMAN_DEFAULT_STATE } from 'gentleman-signals-state-manager';
+import { AppSignalKeys } from 'src/app/models/signals.model';
 import { SignalsManagerService } from 'src/app/services/signals-manager.service';
 
 @Component({
   selector: 'app-componentito',
   standalone: true,
   imports: [CommonModule],
-  providers: [
-    { provide: GENTLEMAN_DEFAULT_STATE, useValue: emptyAppSignalState },
-  ],
   templateUrl: './componentito.component.html',
   styleUrls: ['./componentito.component.scss'],
 })

--- a/example/src/app/components/componentito2/componentito2.component.ts
+++ b/example/src/app/components/componentito2/componentito2.component.ts
@@ -1,8 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { Component, inject } from '@angular/core';
 import { User } from '../../models';
-import { GManagerService } from 'gentleman-signals-state-manager';
-import { AppSignalKeys, AppSignalState } from 'src/app/models/signals.model';
+import { AppSignalKeys } from 'src/app/models/signals.model';
 import { SignalsManagerService } from 'src/app/services/signals-manager.service';
 
 @Component({

--- a/projects/gentleman-signals-state-manager/src/lib/provide-state.ts
+++ b/projects/gentleman-signals-state-manager/src/lib/provide-state.ts
@@ -1,0 +1,8 @@
+import { makeEnvironmentProviders } from '@angular/core'
+import { GENTLEMAN_DEFAULT_STATE, State } from './services/g-manager.service';
+
+export function provideInitialState<T>(initialState: State<T>) {
+  return makeEnvironmentProviders([
+    { provide: GENTLEMAN_DEFAULT_STATE, useValue: initialState}
+  ]);
+}

--- a/projects/gentleman-signals-state-manager/src/lib/services/g-manager.service.ts
+++ b/projects/gentleman-signals-state-manager/src/lib/services/g-manager.service.ts
@@ -1,12 +1,14 @@
 import { Inject, Injectable, InjectionToken, WritableSignal } from "@angular/core";
 import { GManager } from "../utilities";
 
-export const GENTLEMAN_DEFAULT_STATE = new InjectionToken('GENTLEMAN_DEFAULT_STATE');
+export type State<T = {}> = { [K in keyof T]: any }
+
+export const GENTLEMAN_DEFAULT_STATE = new InjectionToken<State>('GENTLEMAN_DEFAULT_STATE');
 
 @Injectable({
   providedIn: 'root',
 })
-export class GManagerService<T extends { [K in keyof T]: any }> {
+export class GManagerService<T extends State<T>> {
   singalsManager: GManager<T>;
 
   constructor(@Inject(GENTLEMAN_DEFAULT_STATE) defaultState: T) {

--- a/projects/gentleman-signals-state-manager/src/public-api.ts
+++ b/projects/gentleman-signals-state-manager/src/public-api.ts
@@ -2,3 +2,4 @@
  * Public API Surface of gentleman-signals-state-manager
  */
 export * from './lib/services';
+export * from './lib/provide-state'


### PR DESCRIPTION
Hi Alan. 

This PR enanches how initial state is provided into GManagerService, since environment provides lives outside DI compomponent Tree.

In this case you dont need yo provide default state on every componente. You only set an initial states and see maginc happens.

At the same time i update docs since services mark as `provideIn: root` could not be explicitly providen. Angular creates services from Inject decorator.